### PR TITLE
Installation/Updating scripts fix

### DIFF
--- a/scripts/KL_Update.bat
+++ b/scripts/KL_Update.bat
@@ -11,6 +11,7 @@ SET regkeys[1]="HKEY_CURRENT_USER\SOFTWARE\Grey Havens\Spiral Knights"
 SET regkeys[2]="HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Valve\Steam"
 SET api_url="https://api.github.com/repos/lucas-allegri/KnightLauncher/releases/latest"
 SET download_url="https://github.com/lucas-allegri/KnightLauncher/releases/download/"
+SET filename=KnightLauncher.zip
 SET javaurl="https://javadl.oracle.com/webapps/download/AutoDL?BundleId=245057_d3c52aa6bfa54d3ca74e617f18309292"
 SET javafname=jre_kl.exe
 SET separator=--------------------------------------------------------------------------------
@@ -182,12 +183,6 @@ SET /P url=<temp
 DEL temp
 SET url=%url:"=%
 SET url=%url:      browser_download_url: =%
-SET filename=%url:https://github.com/lucas-allegri/KnightLauncher/releases/download/=%
-ECHO %filename% > temp
-(FOR /F "tokens=1,* delims=/" %%a IN (temp) DO ECHO %%b) > temp2
-SET /P filename=<temp2
-DEL temp
-DEL temp2
 
 :: Downloading, installing and running the new version.
 :: NOTE: If "tar" fails - update to Windows 10, or update your Windows 10. Build 17063 at least.

--- a/scripts/KL_Update.bat
+++ b/scripts/KL_Update.bat
@@ -1,7 +1,7 @@
 @echo off
 :: by Crowfunder
 :: my gh: https://github.com/Crowfunder
-:: KnightLauncher gh: https://github.com/lucas-allegri/KnightLauncher
+:: KnightLauncher gh: https://github.com/lucasluqui/KnightLauncher
 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
 :: Set Constant Vars
@@ -9,8 +9,8 @@
 :: For now "download_url" is purely informational.
 SET regkeys[1]="HKEY_CURRENT_USER\SOFTWARE\Grey Havens\Spiral Knights"
 SET regkeys[2]="HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Valve\Steam"
-SET api_url="https://api.github.com/repos/lucas-allegri/KnightLauncher/releases/latest"
-SET download_url="https://github.com/lucas-allegri/KnightLauncher/releases/download/"
+SET api_url="https://api.github.com/repos/lucasluqui/KnightLauncher/releases/latest"
+SET download_url="https://github.com/lucasluqui/KnightLauncher/releases/download/"
 SET filename=KnightLauncher.zip
 SET javaurl="https://javadl.oracle.com/webapps/download/AutoDL?BundleId=245057_d3c52aa6bfa54d3ca74e617f18309292"
 SET javafname=jre_kl.exe

--- a/scripts/KL_Update.sh
+++ b/scripts/KL_Update.sh
@@ -6,6 +6,7 @@
 GREEN="\033[0;32m"
 NONE="\033[0m"
 RED="\033[0;31m"
+filename=KnightLauncher.zip
 
 # Checking if script was run inside Spiral Knights directory. If not, it asks for inputting game's main directory full path. Broken if somebody somehow has random "rsrc" and "scenes" folders in place where script is running. Too bad.
 if [[ -d "rsrc" && -d "scenes" && -f "code/projectx-pcode.jar" ]]; then
@@ -38,8 +39,7 @@ case $opt in
 
         # Downloading and installing new version.
         echo "Downloading..."
-        curl -sSL https://api.github.com/repos/lucas-allegri/KnightLauncher/releases/latest | grep "browser_download_url" | cut -d : -f 2,3 | tr -d \" | wget --show-progress -qi -
-        filename=$(curl -sSL https://api.github.com/repos/lucas-allegri/KnightLauncher/releases/latest | jq '.assets[0].name' | tr -d \")
+        curl -sSL https://api.github.com/repos/lucas-allegri/KnightLauncher/releases/latest | grep "browser_download_url" | cut -d : -f 2,3 | tr -d \" | wget --show-progress -O "${filename}" -qi -
         echo -e "${GREEN}Successfully downloaded ${filename}${NONE}\nExtracting..."
         mv "${filename}" "${skpath}/${filename}"
         unzip "${skpath}/${filename}" -d "${skpath}"

--- a/scripts/KL_Update.sh
+++ b/scripts/KL_Update.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # by Crowfunder
 # my gh: https://github.com/Crowfunder
-# KnightLauncher gh: https://github.com/lucas-allegri/KnightLauncher
+# KnightLauncher gh: https://github.com/lucasluqui/KnightLauncher
 
 GREEN="\033[0;32m"
 NONE="\033[0m"
@@ -39,7 +39,7 @@ case $opt in
 
         # Downloading and installing new version.
         echo "Downloading..."
-        curl -sSL https://api.github.com/repos/lucas-allegri/KnightLauncher/releases/latest | grep "browser_download_url" | cut -d : -f 2,3 | tr -d \" | wget --show-progress -O "${filename}" -qi -
+        curl -sSL https://api.github.com/repos/lucasluqui/KnightLauncher/releases/latest | grep "browser_download_url" | cut -d : -f 2,3 | tr -d \" | wget --show-progress -O "${filename}" -qi -
         echo -e "${GREEN}Successfully downloaded ${filename}${NONE}\nExtracting..."
         mv "${filename}" "${skpath}/${filename}"
         unzip "${skpath}/${filename}" -d "${skpath}"


### PR DESCRIPTION
So, the thing is, Lucas changed their Github username and since the script relied on a hardcoded url containing the username, one of the string trim commands would fail. Removed the aforementioned reliance and as a result, fixed both scripts permanently.

Detailed
1. Script fetches the api data from an url containing the legacy username, fortunately Github redirects it to the new one
2. The script gets the latest release download url
3. It trims the download url using a hardcoded url fragment to get the precise filename
4. Fails, because expected "lucas-allegri", and got "lucasluqui" instead

_**Requesting a quick merge and update of the releases, since the script does not work right now**_