### PR TITLE
Change handles from int to long

### DIFF
--- a/src/main/java/com/lucasallegri/util/WinRegistry.java
+++ b/src/main/java/com/lucasallegri/util/WinRegistry.java
@@ -48,25 +48,25 @@ public class WinRegistry {
 
   static {
     try {
-      regOpenKey = userClass.getDeclaredMethod("WindowsRegOpenKey", int.class, byte[].class, int.class);
+      regOpenKey = userClass.getDeclaredMethod("WindowsRegOpenKey", long.class, byte[].class, int.class);
       regOpenKey.setAccessible(true);
-      regCloseKey = userClass.getDeclaredMethod("WindowsRegCloseKey", int.class);
+      regCloseKey = userClass.getDeclaredMethod("WindowsRegCloseKey", long.class);
       regCloseKey.setAccessible(true);
-      regQueryValueEx = userClass.getDeclaredMethod("WindowsRegQueryValueEx", int.class, byte[].class);
+      regQueryValueEx = userClass.getDeclaredMethod("WindowsRegQueryValueEx", long.class, byte[].class);
       regQueryValueEx.setAccessible(true);
-      regEnumValue = userClass.getDeclaredMethod("WindowsRegEnumValue", int.class, int.class, int.class);
+      regEnumValue = userClass.getDeclaredMethod("WindowsRegEnumValue", long.class, int.class, int.class);
       regEnumValue.setAccessible(true);
-      regQueryInfoKey = userClass.getDeclaredMethod("WindowsRegQueryInfoKey1", int.class);
+      regQueryInfoKey = userClass.getDeclaredMethod("WindowsRegQueryInfoKey1", long.class);
       regQueryInfoKey.setAccessible(true);
-      regEnumKeyEx = userClass.getDeclaredMethod("WindowsRegEnumKeyEx", int.class, int.class, int.class);
+      regEnumKeyEx = userClass.getDeclaredMethod("WindowsRegEnumKeyEx", long.class, int.class, int.class);
       regEnumKeyEx.setAccessible(true);
-      regCreateKeyEx = userClass.getDeclaredMethod("WindowsRegCreateKeyEx", int.class, byte[].class);
+      regCreateKeyEx = userClass.getDeclaredMethod("WindowsRegCreateKeyEx", long.class, byte[].class);
       regCreateKeyEx.setAccessible(true);
-      regSetValueEx = userClass.getDeclaredMethod("WindowsRegSetValueEx", int.class, byte[].class, byte[].class);
+      regSetValueEx = userClass.getDeclaredMethod("WindowsRegSetValueEx", long.class, byte[].class, byte[].class);
       regSetValueEx.setAccessible(true);
-      regDeleteValue = userClass.getDeclaredMethod("WindowsRegDeleteValue", int.class, byte[].class);
+      regDeleteValue = userClass.getDeclaredMethod("WindowsRegDeleteValue", long.class, byte[].class);
       regDeleteValue.setAccessible(true);
-      regDeleteKey = userClass.getDeclaredMethod("WindowsRegDeleteKey", int.class, byte[].class);
+      regDeleteKey = userClass.getDeclaredMethod("WindowsRegDeleteKey", long.class, byte[].class);
       regDeleteKey.setAccessible(true);
     } catch (Exception e) {
       e.printStackTrace();


### PR DESCRIPTION
A change was made in OpenJDK 11 that altered some handle types from int to long. [Refer to this commit](https://github.com/AdoptOpenJDK/openjdk-jdk11/commit/1caa6fcbfbbdc5f6f00b4f90562e2772b8bec065#diff-8f418d108b62bb6aca97a716d72ce680fb95070a8e83fba5cf491612a0d18fc6R175)
Knight Launcher would crash in some JDK versions with error:
```
java.lang.NoSuchMethodException: java.util.prefs.WindowsPreferences.WindowsRegOpenKey(int,[B,int)
    at java.base/java.lang.Class.getDeclaredMethod(Class.java:2675)
    at com.lucasallegri.util.WinRegistry.<clinit>(WinRegistry.java:51)
    at com.lucasallegri.util.SteamUtil.getGamePathWindows(SteamUtil.java:19)
    at com.lucasallegri.launcher.settings.SettingsProperties.finishLoading(SettingsProperties.java:110)
    at com.lucasallegri.launcher.settings.SettingsProperties.load(SettingsProperties.java:106)
    at com.lucasallegri.launcher.settings.SettingsProperties.setup(SettingsProperties.java:37)
    at com.lucasallegri.launcher.LauncherApp.<init>(LauncherApp.java:64)
    at com.lucasallegri.launcher.LauncherApp.main(LauncherApp.java:44)
```


### **This however, is only a proposed solution, that may not be backwards compatible with pre-11 JDK versions and needs proper testing.**