### PR TITLE
Support code mods

### DIFF
--- a/src/main/java/com/lucasallegri/bootstrap/ProjectXBootstrap.java
+++ b/src/main/java/com/lucasallegri/bootstrap/ProjectXBootstrap.java
@@ -200,13 +200,23 @@ public class ProjectXBootstrap {
         modName = jar.getName();
       }
       System.out.println("Mod '" + modName + "' initializing");
+      Class<?> clazz = null;
       try {
-        Class.forName(className);
-        System.out.println("Mod '" + modName + "' initialized");
+        clazz = Class.forName(className);
       } catch (Exception e) {
         System.out.println("Failed to load mod '" + modName + "'");
         e.printStackTrace();
       }
+      if (clazz != null) {
+        try {
+          Method method = clazz.getDeclaredMethod("mount");
+          method.setAccessible(true);
+          method.invoke(null);
+        } catch (Exception e) {
+          System.out.println("Mod '" + modName + "' does not define `mount` method");
+        }
+      }
+      System.out.println("Mod '" + modName + "' initialized");
     }
   }
 

--- a/src/main/java/com/lucasallegri/bootstrap/ProjectXBootstrap.java
+++ b/src/main/java/com/lucasallegri/bootstrap/ProjectXBootstrap.java
@@ -13,6 +13,7 @@ import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -148,6 +149,8 @@ public class ProjectXBootstrap {
     if (jars.isEmpty()) {
       return;
     }
+    // Load mods in filename order
+    jars.sort(Comparator.comparing(File::getName));
     loadJars(jars);
     loadClasses(jars);
   }

--- a/src/main/java/com/lucasallegri/bootstrap/ProjectXBootstrap.java
+++ b/src/main/java/com/lucasallegri/bootstrap/ProjectXBootstrap.java
@@ -1,0 +1,219 @@
+package com.lucasallegri.bootstrap;
+
+import javax.swing.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.zip.ZipFile;
+
+/**
+ * Bootstraps instead of {@literal com.threerings.projectx.client.ProjectXApp} for loading mods and language packs.
+ * <p>
+ * Makes sure the "META-INF/MANIFEST.MF" is included in each mod jars,
+ * and the main class must be specified.
+ *
+ * @author Leego Yih
+ */
+public class ProjectXBootstrap {
+  private static final String USER_DIR = System.getProperty("user.dir");
+  private static final String CODE_MODS_DIR = USER_DIR + "/code-mods/";
+  private static final String MANIFEST_PATH = "META-INF/MANIFEST.MF";
+  private static final String MAIN_CLASS_KEY = "Main-Class:";
+  private static final String NAME_KEY = "Name:";
+
+  public static void main(String[] args) throws Exception {
+    System.setProperty("com.threerings.io.enumPolicy", "ORDINAL");
+    // ak.gm()
+    if ((boolean) invokeMethod("com.samskivert.util.ak", "gm", null, new Object[0])) {
+      UIManager.setLookAndFeel(UIManager.getCrossPlatformLookAndFeelClassName());
+    }
+    // X.dM("projectx.log");
+    invokeMethod("com.threerings.util.X", "dM", null, new Object[]{"projectx.log"});
+
+    loadJarMods();
+
+    String ticket = null;
+    String password;
+    for (int i = 0; i < args.length; ++i) {
+      if ((password = args[i]).startsWith("+connect=")) {
+        ticket = password;
+        // com.samskivert.util.c.b(args, i, 1);
+        args = (String[]) invokeMethod("com.samskivert.util.c", "b", null, new Object[]{args, i, 1});
+        break;
+      }
+    }
+    String username = args.length > 0 ? args[0] : System.getProperty("username");
+    password = args.length > 1 ? args[1] : System.getProperty("password");
+    boolean encrypted = Boolean.getBoolean("encrypted");
+    String knight = args.length > 2 ? args[2] : System.getProperty("knight");
+    String action = args.length > 3 ? args[3] : System.getProperty("action");
+    String arg = args.length > 4 ? args[4] : System.getProperty("arg");
+    String sessionKey = System.getProperty("sessionKey");
+
+    Constructor<?> constructor = Class.forName("com.threerings.projectx.client.ProjectXApp")
+        .getDeclaredConstructor(String.class, String.class, boolean.class, String.class, String.class, String.class, String.class, String.class);
+    constructor.setAccessible(true);
+    Object app = constructor.newInstance(username, password, encrypted, knight, action, arg, sessionKey, ticket);
+    invokeMethod("com.threerings.projectx.client.ProjectXApp", "startup", app, new Object[0]);
+  }
+
+  static void loadJarMods() {
+    // Read disabled jar mods from KnightLauncher.properties
+    Set<String> disabledJarMods = new HashSet<>();
+    String disabledJarModsString = getConfigValue("modloader.disabledMods");
+    if (disabledJarModsString != null && disabledJarModsString.length() > 0) {
+      for (String disabledJarMod : disabledJarModsString.split(",")) {
+        disabledJarMod = disabledJarMod.trim();
+        if (disabledJarMod.length() > 0) {
+          disabledJarMods.add(disabledJarMod);
+        }
+      }
+    }
+    // Obtain the mod files in the "/code-mods/" directory
+    File codeModsDir = new File(CODE_MODS_DIR);
+    if (!codeModsDir.exists()) {
+      return;
+    }
+    File[] files = codeModsDir.listFiles();
+    if (files == null || files.length == 0) {
+      return;
+    }
+    List<File> jars = new ArrayList<File>(files.length);
+    for (File file : files) {
+      String filename = file.getName();
+      if (filename.endsWith(".jar")
+          && !disabledJarMods.contains(filename)) {
+        jars.add(file);
+      }
+    }
+    if (jars.isEmpty()) {
+      return;
+    }
+    loadJars(jars);
+    loadClasses(jars);
+  }
+
+  static void loadJars(List<File> jars) {
+    // TODO Compatible with more versions of the JDK
+    Method method;
+    try {
+      method = URLClassLoader.class.getDeclaredMethod("addURL", URL.class);
+    } catch (Exception e) {
+      e.printStackTrace();
+      return;
+    }
+    URLClassLoader classLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
+    boolean accessible = method.isAccessible();
+    method.setAccessible(true);
+    for (File jar : jars) {
+      try {
+        method.invoke(classLoader, jar.toURI().toURL());
+        System.out.println("Loaded jar '" + jar.getName() + "'");
+      } catch (Exception e) {
+        System.out.println("Failed to load jar '" + jar.getName() + "'");
+        e.printStackTrace();
+      }
+    }
+    method.setAccessible(accessible);
+  }
+
+  static void loadClasses(List<File> jars) {
+    for (File jar : jars) {
+      String manifest = readZip(jar, MANIFEST_PATH);
+      if (manifest == null || manifest.length() == 0) {
+        System.out.println("Failed to read '" + MANIFEST_PATH + "' from '" + jar.getName() + "'");
+        continue;
+      }
+      String className = null;
+      String modName = null;
+      for (String item : manifest.split("\n")) {
+        if (item.startsWith(MAIN_CLASS_KEY)) {
+          className = item.replace(MAIN_CLASS_KEY, "").trim();
+        } else if (item.startsWith(NAME_KEY)) {
+          modName = item.replace(NAME_KEY, "").trim();
+        }
+      }
+      if (className == null || className.length() == 0) {
+        System.out.println("Failed to read 'Main-Class' from '" + jar.getName() + "'");
+        continue;
+      }
+      if (modName == null) {
+        modName = jar.getName();
+      }
+      System.out.println("Mod '" + modName + "' initializing");
+      try {
+        Class.forName(className);
+        System.out.println("Mod '" + modName + "' initialized");
+      } catch (Exception e) {
+        System.out.println("Failed to load mod '" + modName + "'");
+        e.printStackTrace();
+      }
+    }
+  }
+
+  static String readZip(File file, String entry) {
+    StringBuilder sb = new StringBuilder();
+    try {
+      ZipFile zip = new ZipFile(file);
+      InputStream is = zip.getInputStream(zip.getEntry(entry));
+      BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+      String s;
+      while ((s = reader.readLine()) != null) {
+        sb.append(s).append("\n");
+      }
+      reader.close();
+      zip.close();
+      return sb.toString();
+    } catch (Exception e) {
+      System.out.println("Failed to read '" + file.getName() + "'");
+      e.printStackTrace();
+      return null;
+    }
+  }
+
+  static String getConfigValue(String key) {
+    Properties _prop = new Properties();
+    String value;
+    try (InputStream is = Files.newInputStream(Paths.get(System.getProperty("user.dir") + File.separator + "KnightLauncher.properties"))) {
+      _prop.load(is);
+      value = _prop.getProperty(key);
+      return value;
+    } catch (IOException ignored) {
+    }
+    return null;
+  }
+
+  static Object invokeMethod(String className, String methodName, Object object, Object[] args) throws Exception {
+    Class<?> clazz = Class.forName(className);
+    Method[] methods = clazz.getDeclaredMethods();
+    for (int i = 0; i < methods.length; i++) {
+      Method method = methods[i];
+      if (method.getName().equals(methodName)) {
+        method.setAccessible(true);
+        return method.invoke(object, args);
+      }
+    }
+    methods = clazz.getMethods();
+    for (int i = 0; i < methods.length; i++) {
+      Method method = methods[i];
+      if (method.getName().equals(methodName)) {
+        method.setAccessible(true);
+        return method.invoke(object, args);
+      }
+    }
+    throw new NoSuchMethodException(methodName);
+  }
+}

--- a/src/main/java/com/lucasallegri/launcher/LauncherApp.java
+++ b/src/main/java/com/lucasallegri/launcher/LauncherApp.java
@@ -64,6 +64,7 @@ public class LauncherApp {
     DiscordRPC.getInstance().start();
     KeyboardController.start();
     checkDirectories();
+    LauncherDigester.doDigest();
     if (SystemUtil.isWindows()) checkShortcut();
   }
 

--- a/src/main/java/com/lucasallegri/launcher/LauncherDigester.java
+++ b/src/main/java/com/lucasallegri/launcher/LauncherDigester.java
@@ -1,0 +1,160 @@
+package com.lucasallegri.launcher;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.security.MessageDigest;
+
+/**
+ * @author Leego Yih
+ */
+public class LauncherDigester {
+  public static final String KL_JAR_PATH = "/KnightLauncher.jar";
+  public static final String KL_JARV_PATH = "/KnightLauncher.jarv";
+  public static final String GETDOWN_PATH = "/getdown.txt";
+  public static final String DIGEST_PATH = "/digest.txt";
+  public static final String MAGIC_HEAD = "# Customized by KnightLauncher";
+  public static final String GETDOWN_PROJECTXAPP_CLASS = "class = com.threerings.projectx.client.ProjectXApp";
+  public static final String GETDOWN_PROJECTXAPP_CLIENT_CLASS = "client.class = com.threerings.projectx.client.ProjectXApp";
+  public static final String GETDOWN_BOOTSTRAP_CLASS = "class = com.lucasallegri.bootstrap.ProjectXBootstrap";
+  public static final String GETDOWN_BOOTSTRAP_CLIENT_CLASS = "client.class = com.lucasallegri.bootstrap.ProjectXBootstrap";
+  public static final String GETDOWN_KL_JAR = "code = KnightLauncher.jar";
+
+  public static void doDigest() {
+    try {
+      // Guarantee that the files exists
+      File klJarFile = new File(LauncherGlobals.USER_DIR + KL_JAR_PATH);
+      File klJarvFile = new File(LauncherGlobals.USER_DIR + KL_JARV_PATH);
+      File getdownFile = new File(LauncherGlobals.USER_DIR + GETDOWN_PATH);
+      File digestFile = new File(LauncherGlobals.USER_DIR + DIGEST_PATH);
+      String getdownContent = readFile(getdownFile).trim();
+      String digestContent = readFile(digestFile).trim();
+      // Build a new "getdown.txt" file if it has not been modified by KL
+      if (!getdownContent.startsWith(MAGIC_HEAD)) {
+        getdownFile.renameTo(new File(getdownFile.getAbsoluteFile() + ".bak"));
+        getdownContent = getdownContent
+            .replace("\n"+GETDOWN_PROJECTXAPP_CLIENT_CLASS, "\n#" + GETDOWN_PROJECTXAPP_CLIENT_CLASS)
+            .replace("\n"+GETDOWN_PROJECTXAPP_CLASS, "\n#" + GETDOWN_PROJECTXAPP_CLASS);
+        StringBuilder sb = new StringBuilder()
+            .append(MAGIC_HEAD).append("\n")
+            .append(getdownContent).append("\n\n")
+            .append("# KnightLauncher resources").append("\n")
+            .append(GETDOWN_KL_JAR).append("\n")
+            .append(GETDOWN_BOOTSTRAP_CLASS).append("\n")
+            .append(GETDOWN_BOOTSTRAP_CLIENT_CLASS).append("\n");
+        writeFile(getdownFile, sb.toString());
+      }
+      // For Windows
+      if (!klJarvFile.exists()) {
+        klJarvFile.createNewFile();
+      }
+      // Calculate the MD5 of the files
+      String klMD5 = md5(klJarFile.getAbsolutePath());
+      String getdownMD5 = md5(getdownFile.getAbsolutePath());
+      // Build a new "digest.txt" file from the original one
+      digestContent = digestContent.trim();
+      digestContent = digestContent.replaceFirst("digest\\.txt = \\S+", "");
+      digestContent = digestContent.replaceFirst("getdown\\.txt = \\S+\n", "getdown.txt = " + getdownMD5 + "\n");
+      if (digestContent.indexOf("KnightLauncher.jar") > 0) {
+        digestContent = digestContent.replaceFirst("KnightLauncher\\.jar = \\S+\n", "KnightLauncher.jar = " + klMD5 + "\n");
+      } else {
+        digestContent = digestContent + "KnightLauncher.jar = " + klMD5 + "\n";
+      }
+      // Append the final MD5 to the end
+      String digestMD5 = md5(digestContent.getBytes("UTF-8"));
+      digestContent = digestContent + "digest.txt = " + digestMD5 + "\n";
+      writeFile(digestFile, digestContent);
+      Log.log.info(String.format("\nKnightLauncher.jar: %s\ngetdown.txt: %s\ndigest.txt: %s\n", klMD5, getdownMD5, digestMD5));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  static String readFile(File file) throws IOException {
+    StringBuilder sb = new StringBuilder();
+    BufferedReader reader = new BufferedReader(new FileReader(file));
+    String s;
+    while ((s = reader.readLine()) != null) {
+      sb.append(s).append("\n");
+    }
+    reader.close();
+    return sb.toString();
+  }
+
+  static void writeFile(File file, String s) throws IOException {
+    FileWriter writer = new FileWriter(file);
+    writer.write(s);
+    writer.flush();
+    writer.close();
+  }
+
+  static String md5(String path) throws Exception {
+    File file = new File(path);
+    byte[] data = new byte[(int) file.length()];
+    FileInputStream fis = new FileInputStream(file);
+    fis.read(data);
+    fis.close();
+    return md5(data);
+  }
+
+  static String md5(byte[] data) throws Exception {
+    byte[] hash = MessageDigest.getInstance("MD5").digest(data);
+    return encodeHex(hash);
+  }
+
+  /** Table for byte to hex string translation. */
+  static final char[] HEX = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
+  /** Table for HEX to DEC byte translation. */
+  static final int[] DEC = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15};
+
+  static int getDec(int index) {
+    // Fast for correct values, slower for incorrect ones
+    try {
+      return DEC[index - 48];
+    } catch (ArrayIndexOutOfBoundsException e) {
+      return -1;
+    }
+  }
+
+  static byte getHex(int index) {
+    return (byte) HEX[index];
+  }
+
+  static String encodeHex(byte[] bytes) {
+    if (null == bytes) {
+      return null;
+    }
+    int i = 0;
+    char[] chars = new char[bytes.length << 1];
+    for (byte b : bytes) {
+      chars[i++] = HEX[(b & 0xf0) >> 4];
+      chars[i++] = HEX[b & 0x0f];
+    }
+    return new String(chars);
+  }
+
+  static byte[] decodeHex(String input) {
+    if (input == null) {
+      return null;
+    }
+    if ((input.length() & 1) == 1) {
+      // Odd number of characters
+      throw new IllegalArgumentException("Odd digits");
+    }
+    char[] inputChars = input.toCharArray();
+    byte[] result = new byte[input.length() >> 1];
+    for (int i = 0; i < result.length; i++) {
+      int upperNibble = getDec(inputChars[2 * i]);
+      int lowerNibble = getDec(inputChars[2 * i + 1]);
+      if (upperNibble < 0 || lowerNibble < 0) {
+        // Non hex character
+        throw new IllegalArgumentException("Non hex");
+      }
+      result[i] = (byte) ((upperNibble << 4) + lowerNibble);
+    }
+    return result;
+  }
+}

--- a/src/main/java/com/lucasallegri/launcher/LauncherGlobals.java
+++ b/src/main/java/com/lucasallegri/launcher/LauncherGlobals.java
@@ -25,81 +25,92 @@ public class LauncherGlobals {
 
   public static final String RPC_CLIENT_ID = "626524043209867274";
 
+  public static final String[] GETDOWN_ARGS;
+  public static final String[] GETDOWN_ARGS_WIN;
+  public static final String[] ALT_CLIENT_ARGS;
+  public static final String[] ALT_CLIENT_ARGS_WIN;
 
-  public static final String[] GETDOWN_ARGS = {
-          "./java/bin/java",
-          "-Dsun.java2d.d3d=false",
-          "-Dcheck_unpacked=true",
-          "-jar",
-          "./getdown-pro.jar",
-          ".",
-          "client"
-  };
-
-  public static final String[] GETDOWN_ARGS_WIN = {
-          ".\\java_vm\\bin\\java.exe",
-          "-Dsun.java2d.d3d=false",
-          "-Dcheck_unpacked=true",
-          "-jar",
-          USER_DIR + File.separator + "getdown-pro.jar",
-          ".",
-          "client"
-  };
-
-  public static final String[] ALT_CLIENT_ARGS = {
-          "./java/bin/java",
-          "-classpath",
-          USER_DIR + File.separator + "./code/config.jar:" +
-                  USER_DIR + File.separator + "./code/projectx-config.jar:" +
-                  USER_DIR + File.separator + "./code/projectx-pcode.jar:" +
-                  USER_DIR + File.separator + "./code/lwjgl.jar:" +
-                  USER_DIR + File.separator + "./code/lwjgl_util.jar:" +
-                  USER_DIR + File.separator + "./code/jinput.jar:" +
-                  USER_DIR + File.separator + "./code/jutils.jar:" +
-                  USER_DIR + File.separator + "./code/jshortcut.jar:" +
-                  USER_DIR + File.separator + "./code/commons-beanutils.jar:" +
-                  USER_DIR + File.separator + "./code/commons-digester.jar:" +
-                  USER_DIR + File.separator + "./code/commons-logging.jar:",
-          "-Dcom.threerings.getdown=false",
-          "-Xms256M",
-          "-Xmx512M",
-          "-XX:+AggressiveOpts",
-          "-XX:SoftRefLRUPolicyMSPerMB=10",
-          "-Djava.library.path=" + USER_DIR + File.separator + "./native",
-          "-Dorg.lwjgl.util.NoChecks=true",
-          "-Dsun.java2d.d3d=false",
-          "-Dappdir=" + USER_DIR + File.separator + ".",
-          "-Dresource_dir=" + USER_DIR + File.separator + "./rsrc",
-          "-XX:+UseStringDeduplication",
-          "com.threerings.projectx.client.ProjectXApp",
-  };
-
-  public static final String[] ALT_CLIENT_ARGS_WIN = {
-          "./java_vm/bin/java",
-          "-classpath",
-          USER_DIR + File.separator + "./code/config.jar;" +
-          USER_DIR + File.separator + "./code/projectx-config.jar;" +
-          USER_DIR + File.separator + "./code/projectx-pcode.jar;" +
-          USER_DIR + File.separator + "./code/lwjgl.jar;" +
-          USER_DIR + File.separator + "./code/lwjgl_util.jar;" +
-          USER_DIR + File.separator + "./code/jinput.jar;" +
-          USER_DIR + File.separator + "./code/jutils.jar;" +
-          USER_DIR + File.separator + "./code/jshortcut.jar;" +
-          USER_DIR + File.separator + "./code/commons-beanutils.jar;" +
-          USER_DIR + File.separator + "./code/commons-digester.jar;" +
-          USER_DIR + File.separator + "./code/commons-logging.jar;",
-          "-Dcom.threerings.getdown=false",
-          "-Xms256M",
-          "-Xmx512M",
-          "-XX:+AggressiveOpts",
-          "-XX:SoftRefLRUPolicyMSPerMB=10",
-          "-Djava.library.path=" + USER_DIR + File.separator + "./native",
-          "-Dorg.lwjgl.util.NoChecks=true",
-          "-Dsun.java2d.d3d=false",
-          "-Dappdir=" + USER_DIR + File.separator + ".",
-          "-Dresource_dir=" + USER_DIR + File.separator + "./rsrc",
-          "-XX:+UseStringDeduplication",
-          "com.threerings.projectx.client.ProjectXApp",
-  };
+  static {
+    String javaPath;
+    if (new File(USER_DIR + File.separator + "./java/bin/java").exists()) {
+      javaPath = "./java/bin/java";
+    } else {
+      javaPath = "./java_vm/bin/java";
+    }
+    GETDOWN_ARGS = new String[]{
+        javaPath,
+        "-Dsun.java2d.d3d=false",
+        "-Dcheck_unpacked=true",
+        "-jar",
+        "./getdown-pro.jar",
+        ".",
+        "client"
+    };
+    GETDOWN_ARGS_WIN = new String[]{
+        javaPath,
+        "-Dsun.java2d.d3d=false",
+        "-Dcheck_unpacked=true",
+        "-jar",
+        USER_DIR + File.separator + "getdown-pro.jar",
+        ".",
+        "client"
+    };
+    ALT_CLIENT_ARGS = new String[]{
+        javaPath,
+        "-classpath",
+        USER_DIR + File.separator + "./code/config.jar:" +
+            USER_DIR + File.separator + "./code/projectx-config.jar:" +
+            USER_DIR + File.separator + "./code/projectx-pcode.jar:" +
+            USER_DIR + File.separator + "./code/lwjgl.jar:" +
+            USER_DIR + File.separator + "./code/lwjgl_util.jar:" +
+            USER_DIR + File.separator + "./code/jinput.jar:" +
+            USER_DIR + File.separator + "./code/jutils.jar:" +
+            USER_DIR + File.separator + "./code/jshortcut.jar:" +
+            USER_DIR + File.separator + "./code/commons-beanutils.jar:" +
+            USER_DIR + File.separator + "./code/commons-digester.jar:" +
+            USER_DIR + File.separator + "./code/commons-logging.jar:" +
+            USER_DIR + File.separator + "./KnightLauncher.jar:",
+        "-Dcom.threerings.getdown=false",
+        "-Xms256M",
+        "-Xmx512M",
+        "-XX:+AggressiveOpts",
+        "-XX:SoftRefLRUPolicyMSPerMB=10",
+        "-Djava.library.path=" + USER_DIR + File.separator + "./native",
+        "-Dorg.lwjgl.util.NoChecks=true",
+        "-Dsun.java2d.d3d=false",
+        "-Dappdir=" + USER_DIR + File.separator + ".",
+        "-Dresource_dir=" + USER_DIR + File.separator + "./rsrc",
+        "-XX:+UseStringDeduplication",
+        "com.lucasallegri.bootstrap.ProjectXBootstrap",
+    };
+    ALT_CLIENT_ARGS_WIN = new String[]{
+        javaPath,
+        "-classpath",
+        USER_DIR + File.separator + "./code/config.jar;" +
+            USER_DIR + File.separator + "./code/projectx-config.jar;" +
+            USER_DIR + File.separator + "./code/projectx-pcode.jar;" +
+            USER_DIR + File.separator + "./code/lwjgl.jar;" +
+            USER_DIR + File.separator + "./code/lwjgl_util.jar;" +
+            USER_DIR + File.separator + "./code/jinput.jar;" +
+            USER_DIR + File.separator + "./code/jutils.jar;" +
+            USER_DIR + File.separator + "./code/jshortcut.jar;" +
+            USER_DIR + File.separator + "./code/commons-beanutils.jar;" +
+            USER_DIR + File.separator + "./code/commons-digester.jar;" +
+            USER_DIR + File.separator + "./code/commons-logging.jar;" +
+            USER_DIR + File.separator + "./KnightLauncher.jar;",
+        "-Dcom.threerings.getdown=false",
+        "-Xms256M",
+        "-Xmx512M",
+        "-XX:+AggressiveOpts",
+        "-XX:SoftRefLRUPolicyMSPerMB=10",
+        "-Djava.library.path=" + USER_DIR + File.separator + "./native",
+        "-Dorg.lwjgl.util.NoChecks=true",
+        "-Dsun.java2d.d3d=false",
+        "-Dappdir=" + USER_DIR + File.separator + ".",
+        "-Dresource_dir=" + USER_DIR + File.separator + "./rsrc",
+        "-XX:+UseStringDeduplication",
+        "com.lucasallegri.bootstrap.ProjectXBootstrap",
+    };
+  }
 
 }

--- a/src/main/java/com/lucasallegri/launcher/mods/ModListGUI.java
+++ b/src/main/java/com/lucasallegri/launcher/mods/ModListGUI.java
@@ -312,6 +312,9 @@ public class ModListGUI extends BaseGUI {
   }
 
   public static void updateModList() {
+    if (modListContainer == null) {
+      return;
+    }
     int idx = modListContainer.getSelectedIndex();
     modListContainer.removeAll();
     for (Mod mod : ModLoader.getModList()) {

--- a/src/main/java/com/lucasallegri/launcher/mods/ModLoader.java
+++ b/src/main/java/com/lucasallegri/launcher/mods/ModLoader.java
@@ -34,22 +34,23 @@ public class ModLoader {
     if (getModCount() > 0) clearModList();
 
     // Append all .zip and .jar files inside the mod folder into an ArrayList.
-    List<String> rawFiles = FileUtil.fileNamesInDirectory(LauncherGlobals.USER_DIR + "/mods/", ".zip");
-    rawFiles.addAll(FileUtil.fileNamesInDirectory(LauncherGlobals.USER_DIR + "/code-mods/", ".jar"));
+    List<File> rawFiles = FileUtil.filesInDirectory(LauncherGlobals.USER_DIR + "/mods/", ".zip");
+    rawFiles.addAll(FileUtil.filesInDirectory(LauncherGlobals.USER_DIR + "/code-mods/", ".jar"));
 
-    for (String file : rawFiles) {
+    for (File file : rawFiles) {
       JSONObject modJson;
       try {
-        modJson = new JSONObject(Compressor.readFileInsideZip(LauncherGlobals.USER_DIR + "/mods/" + file, "mod.json")).getJSONObject("mod");
+        modJson = new JSONObject(Compressor.readFileInsideZip(file.getAbsolutePath(), "mod.json")).getJSONObject("mod");
       } catch (Exception e) {
         modJson = null;
       }
 
+      String fileName = file.getName();
       Mod mod = null;
-      if (file.endsWith("zip")) {
-        mod = new ZipMod(file);
-      } else if (file.endsWith("jar")) {
-        mod = new JarMod(file);
+      if (fileName.endsWith("zip")) {
+        mod = new ZipMod(fileName);
+      } else if (fileName.endsWith("jar")) {
+        mod = new JarMod(fileName);
       }
 
       if (mod != null && modJson != null) {
@@ -63,8 +64,8 @@ public class ModLoader {
       mod.wasAdded();
 
       // Compute a hash for each mod file and check that it matches on every execution, if it doesn't, then rebuild.
-      String hash = Compressor.getZipHash(LauncherGlobals.USER_DIR + "/mods/" + file);
-      String hashFilePath = LauncherGlobals.USER_DIR + "/mods/" + mod.getFileName() + ".hash";
+      String hash = Compressor.getZipHash(file.getAbsolutePath());
+      String hashFilePath = file.getAbsolutePath() + ".hash";
 
       if (FileUtil.fileExists(hashFilePath)) {
         try {
@@ -124,6 +125,7 @@ public class ModLoader {
 
     mountRequired = false;
     ProgressBar.finishTask();
+    LauncherDigester.doDigest();
     LauncherGUI.launchButton.setEnabled(true);
   }
 

--- a/src/main/java/com/lucasallegri/launcher/settings/GameSettings.java
+++ b/src/main/java/com/lucasallegri/launcher/settings/GameSettings.java
@@ -58,8 +58,6 @@ public class GameSettings {
       writer.println(Settings.gameAdditionalArgs);
       writer.close();
 
-      loadConnectionSettings();
-
       ProgressBar.setBarValue(1);
       ProgressBar.finishTask();
     } catch (FileNotFoundException | UnsupportedEncodingException e) {
@@ -67,6 +65,11 @@ public class GameSettings {
     }
   }
 
+  /**
+   * @see com.lucasallegri.bootstrap.ProjectXBootstrap
+   * @deprecated No longer use the way of modifying files.
+   */
+  @Deprecated
   private static void loadConnectionSettings() {
     try {
       FileUtil.extractFileWithinJar("/config/deployment.properties", LauncherGlobals.USER_DIR + "\\deployment.properties");

--- a/src/main/java/com/lucasallegri/util/FileUtil.java
+++ b/src/main/java/com/lucasallegri/util/FileUtil.java
@@ -92,6 +92,21 @@ public class FileUtil {
     return fileNames;
   }
 
+  public static List<File> filesInDirectory(String dir, String ext) {
+
+    File folder = new File(dir);
+    File[] fileList = folder.listFiles();
+    List<File> files = new ArrayList<File>();
+
+    for (int i = 0; i < fileList.length; i++) {
+      if (fileList[i].isDirectory() == false && fileList[i].toString().endsWith(ext)) {
+        files.add(fileList[i]);
+      }
+    }
+
+    return files;
+  }
+
   public static boolean fileExists(String path) {
     File file = new File(path);
     return file.exists();


### PR DESCRIPTION
## 1. ProjectXBootstrap.java (New)

Add `ProjectXBootstrap` to replace `ProjectXApp`, which is used to boot and load jar mods, such as replacing `deployment.properties` at runtime.

## 2. LauncherDigester.java (New)

Add `LauncherDigester` to modify `getdown.txt` and `digest.txt` before SK starts.

`getdown.txt`: 
```
...
# KnightLauncher resources
code = KnightLauncher.jar
class = com.lucasallegri.bootstrap.ProjectXBootstrap
client.class = com.lucasallegri.bootstrap.ProjectXBootstrap
```
`digest.txt`
```
...
KnightLauncher.jar = ...
digest.txt = ...
```

## 3. ModLoader.java (Modified)

It now reads the jar mods correctly

## 4. GameSettings.java (Modified)

[GameSettings.loadConnectionSettings()](https://github.com/lucasluqui/KnightLauncher/blob/c8f89ad085b3fa0ad481314861ad0341f779acf0/src/main/java/com/lucasallegri/launcher/settings/GameSettings.java#L73) is no longer used, it is replaced by [ProjectXBootstrap.loadConnectionSettings()](https://github.com/lucasluqui/KnightLauncher/blob/c8f89ad085b3fa0ad481314861ad0341f779acf0/src/main/java/com/lucasallegri/bootstrap/ProjectXBootstrap.java#L86).

https://github.com/lucasluqui/KnightLauncher/blob/c8f89ad085b3fa0ad481314861ad0341f779acf0/src/main/java/com/lucasallegri/bootstrap/ProjectXBootstrap.java#L86-L117

## 5. LauncherGlobals.java (Modified)

Modify `LauncherGlobals` to detect the jvm path and use `com.lucasallegri.bootstrap.ProjectXBootstrap` instead of `com.threerings.projectx.client.ProjectXApp`.

---

I tested it on Mac and Windows 10 (except Linux), both zip mods and jar mods work:
![image](https://user-images.githubusercontent.com/21337386/217716132-e18a72c1-7f0c-4cf4-ac16-9158d00923a9.png)
